### PR TITLE
Potential fix for code scanning alert no. 12: Uncontrolled data used in path expression

### DIFF
--- a/without/app_final2.py
+++ b/without/app_final2.py
@@ -296,7 +296,11 @@ def summarize_file_audio():
 
     if uploaded_file:
         # Save the uploaded file to the "uploads" folder
-        video_file_path = os.path.join(app.config['UPLOAD_FOLDER'], uploaded_file.filename) # type: ignore
+        from werkzeug.utils import secure_filename
+        sanitized_filename = secure_filename(uploaded_file.filename)
+        video_file_path = os.path.normpath(os.path.join(app.config['UPLOAD_FOLDER'], sanitized_filename))
+        if not video_file_path.startswith(os.path.abspath(app.config['UPLOAD_FOLDER'])):
+            return "Invalid file path."
         uploaded_file.save(video_file_path)
 
         # Process the uploaded video file


### PR DESCRIPTION
Potential fix for [https://github.com/sivamaniPITTALA/Summarizing-Audio-Files-in-Python/security/code-scanning/12](https://github.com/sivamaniPITTALA/Summarizing-Audio-Files-in-Python/security/code-scanning/12)

To fix the issue, we need to validate the user-provided filename (`uploaded_file.filename`) before constructing the file path. A common approach is to use `werkzeug.utils.secure_filename`, which sanitizes the filename by removing potentially dangerous characters and ensuring it is safe to use. Additionally, we should verify that the constructed path remains within the `UPLOAD_FOLDER` after normalization.

Steps to fix:
1. Import `secure_filename` from `werkzeug.utils`.
2. Use `secure_filename` to sanitize `uploaded_file.filename`.
3. Normalize the constructed path using `os.path.normpath`.
4. Verify that the normalized path starts with `UPLOAD_FOLDER` to ensure it does not escape the intended directory.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
